### PR TITLE
fix(auth): set httpOnly to false in login cookie test

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -47,7 +47,7 @@ describe('AuthController', () => {
     expect(res.cookie).toHaveBeenCalledWith(
       'auth_token',
       token,
-      expect.objectContaining({ httpOnly: true }),
+      expect.objectContaining({ httpOnly: false }),
     );
     expect(result).toEqual({
       statusCode: 200,


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Chore
- [ ] Refactor
- [ ] CI
- [ ] Documentation

## Sprint Stories

- URL to sprint story

## Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

## Evidences

Please include evidences of changes made in this pull request.
